### PR TITLE
switch to pages data structure

### DIFF
--- a/hills.lua
+++ b/hills.lua
@@ -923,8 +923,8 @@ local non_indexed_voices = {'delay', 'feedback', 'main'}
 
 function fkmap(i,j,index,p)
   local target_trig;
+  local _page = track[i][j].page
   if hills[i].highway == true then
-    local _page = track[i][j].page
     if track[i][j][_page].trigs[index] then
       target_trig = _fkprm.adjusted_params
     else
@@ -1037,7 +1037,6 @@ local function play_linked_sample(i, j, played_note, vel_target, retrig_index, f
 end
 
 force_note = function(i,j,played_note)
-  print('note happening')
   local vel_target = params:get('hill_'..i..'_iso_velocity')
   local retrig_index = 0
   if params:string('voice_model_'..i) ~= 'sample' then
@@ -1123,8 +1122,8 @@ pass_note = function(i,j,seg,note_val,index,retrig_index)
         if target_trig == _fkprm.adjusted_params then
           for k = 1,#per_step_params_adjusted[i].param do
             local check_prm = per_step_params_adjusted[i].param[k]
-            print('>S>S>S'..check_prm)
-            if _fkprm.adjusted_params[i][j][index].params[check_prm] == nil then
+            -- print('>S>S>S'..check_prm)
+            if _fkprm.adjusted_params[i][j][_page][index].params[check_prm] == nil then
               local lock_trig = track[i][j].focus == 'main' and track[i][j][_page].lock_trigs[index] or track[i][j][_page].fill.lock_trigs[index]
               local is_drum_voice = params.lookup[check_prm] <= last_voice_param
               local id = check_prm
@@ -1135,7 +1134,7 @@ pass_note = function(i,j,seg,note_val,index,retrig_index)
                 target_drum = string.gsub(target_drum, '_', '')
                 local p_name = string.gsub(id,target_voice..'_'..target_drum..'_','')
                 prms.send_to_engine(target_voice,p_name,params:get(id))
-                print('reseeding non-adjusted value for voice', target_voice, j, index, id, p_name)
+                -- print('reseeding non-adjusted value for voice', target_voice, j, index, id, p_name)
               else
                 local p_name = extract_voice_from_string(id)
                 local sc_target = string.gsub(id,p_name..'_','')
@@ -1147,17 +1146,16 @@ pass_note = function(i,j,seg,note_val,index,retrig_index)
         end
         -- this step's entry handling:
         -- per_step_params_adjusted[i] = {param = {}, value = {}}
-        -- for k,v in next,_fkprm.adjusted_params[i][j][index].params do
         for k,v in next,target_trig[i][j][_page][index].params do
-          print('this is ahppening!!')
+          -- print('this is ahppening!!')
           local param_id = k
-          print(k, last_voice_param)
+          -- print(k, last_voice_param)
           k = params.lookup[k]
-          print(k, last_voice_param)
+          -- print(k, last_voice_param)
           local is_drum_voice = k <= last_voice_param
           local drum_target = param_id:match('(.+)_(.+)_(.+)')
           drum_target = tonumber(drum_target)
-          print('huh! '..drum_target, k, params:get_id(k), param_id)
+          -- print('huh! '..drum_target, k, params:get_id(k), param_id)
           if is_drum_voice and type(drum_target) == 'number' and drum_target <= number_of_hills then
             if retrig_index == 0 then
               local target_voice = drum_target
@@ -1165,7 +1163,7 @@ pass_note = function(i,j,seg,note_val,index,retrig_index)
               target_drum = string.gsub(target_drum, target_voice..'_', '')
               target_drum = string.gsub(target_drum, '_', '')
               local p_name = string.gsub(param_id,target_voice..'_'..target_drum..'_','')
-              print('sending voice param',target_voice,p_name,fkmap(i,j,index,param_id))
+              -- print('sending voice param',target_voice,p_name,fkmap(i,j,index,param_id))
               if target_voice ~= i then
                 if not tab.contains(track[target_voice].external_prm_change,param_id) then
                   track[target_voice].external_prm_change[#track[target_voice].external_prm_change+1] = param_id

--- a/hills.lua
+++ b/hills.lua
@@ -891,8 +891,9 @@ end
 
 local function check_subtables(i,j,index)
   local target_trig;
+  local _page = track[i][j].page
   if hills[i].highway == true then
-    if track[i][j].trigs[index] then
+    if track[i][j][_page].trigs[index] then
       target_trig = _fkprm.adjusted_params
     else
       target_trig = _fkprm.adjusted_params_lock_trigs
@@ -902,13 +903,11 @@ local function check_subtables(i,j,index)
   end
   if target_trig[i] ~= nil
   and target_trig[i][j] ~= nil
-  and target_trig[i][j][index] ~= nil
-  and target_trig[i][j][index].params ~= nil
+  and target_trig[i][j][_page][index] ~= nil
+  and target_trig[i][j][_page][index].params ~= nil
   then
-    -- print('yep')
     return true
   else
-    -- print('nope')
     return false
   end
 end
@@ -925,15 +924,17 @@ local non_indexed_voices = {'delay', 'feedback', 'main'}
 function fkmap(i,j,index,p)
   local target_trig;
   if hills[i].highway == true then
-    if track[i][j].trigs[index] then
+    local _page = track[i][j].page
+    if track[i][j][_page].trigs[index] then
       target_trig = _fkprm.adjusted_params
     else
       target_trig = _fkprm.adjusted_params_lock_trigs
     end
   else
+    print('230520: when is this true???')
     target_trig = _fkprm.adjusted_params
   end
-  local value = target_trig[i][j][index].params[p]
+  local value = target_trig[i][j][_page][index].params[p]
   local clamped = util.clamp(value, 0, 1)
   local cs = params:lookup_param(p).controlspec
   local rounded = util_round(cs.warp.map(cs, clamped), cs.step)
@@ -974,31 +975,31 @@ local function process_params_per_step(parent,i,j,k,index)
   end
 end
 
-function play_chord(i,j,index)
-  local chord_target = hills[i].highway == false and hills[i][j].note_num.chord_degree[index] or track[i][j].chord_degrees[index]
-  local base_note;
-  if params:string('hill_'..i..'_mode') == 'highway' then
-    if track[i][j].focus == 'main' then
-      base_note = track[i][j].base_note[index]
-    else
-      base_note = track[i][j].fill.base_note[index]
-    end
-    if base_note == -1 then
-      base_note = params:get(i..'_'..params:string('voice_model_'..i)..'_carHz')
-    end
-  else
-    base_note = params:get('hill '..i..' base note')
-  end
-  -- print(index,base_note)
-  local shell_notes = mu.generate_chord_scale_degree(
-    base_note,
-    params:string('hill '..i..' scale'),
-    chord_target,
-    true
-  )
-  -- engine.set_voice_param(i,"carHzThird",midi_to_hz(shell_notes[2]))
-  -- engine.set_voice_param(i,"carHzSeventh",midi_to_hz(shell_notes[4]))
-end
+-- function play_chord(i,j,index)
+--   local chord_target = hills[i].highway == false and hills[i][j].note_num.chord_degree[index] or track[i][j].chord_degrees[index]
+--   local base_note;
+--   if params:string('hill_'..i..'_mode') == 'highway' then
+--     if track[i][j].focus == 'main' then
+--       base_note = track[i][j].base_note[index]
+--     else
+--       base_note = track[i][j].fill.base_note[index]
+--     end
+--     if base_note == -1 then
+--       base_note = params:get(i..'_'..params:string('voice_model_'..i)..'_carHz')
+--     end
+--   else
+--     base_note = params:get('hill '..i..' base note')
+--   end
+--   -- print(index,base_note)
+--   local shell_notes = mu.generate_chord_scale_degree(
+--     base_note,
+--     params:string('hill '..i..' scale'),
+--     chord_target,
+--     true
+--   )
+--   -- engine.set_voice_param(i,"carHzThird",midi_to_hz(shell_notes[2]))
+--   -- engine.set_voice_param(i,"carHzSeventh",midi_to_hz(shell_notes[4]))
+-- end
 
 local function play_linked_sample(i, j, played_note, vel_target, retrig_index, force)
   if params:string("hill "..i.." sample output") == "yes" then
@@ -1006,7 +1007,8 @@ local function play_linked_sample(i, j, played_note, vel_target, retrig_index, f
       local should_play;
       if hills[i].highway then
         local index = track[i][j].step
-        if track[i][j].trigs[index] or force then
+        local _page = track[i][j].page
+        if track[i][j][_page].trigs[index] or force then
           should_play = true
         end
       else
@@ -1064,8 +1066,9 @@ local function trigger_notes(i,j,index,velocity,retrigger_bool,played_note)
       send_note_data(i,j,index,played_note)
     end
     if hills[i].highway then
-      local focused_notes = track[i][j].focus == 'main' and track[i][j].base_note[index] or track[i][j].fill.base_note[index]
-      local focused_chords = track[i][j].focus == 'main' and track[i][j].chord_notes[index] or track[i][j].fill.chord_notes[index]
+      local _page = track[i][j].page
+      local focused_notes = track[i][j].focus == 'main' and track[i][j][_page].base_note[index] or track[i][j][_page].fill.base_note[index]
+      local focused_chords = track[i][j].focus == 'main' and track[i][j][_page].chord_notes[index] or track[i][j][_page].fill.chord_notes[index]
       local note_check;
       if params:string('voice_model_'..i) ~= 'sample' and params:string('voice_model_'..i) ~= 'input' then
         note_check = params:get(i..'_'..params:string('voice_model_'..i)..'_carHz')
@@ -1087,7 +1090,6 @@ send_note_data = function(i,j,index,played_note)
 end
 
 pass_note = function(i,j,seg,note_val,index,retrig_index)
-  -- print(clock.get_beats(), track[i][j].swing)
   local midi_notes = hills[i].note_ocean
   local played_note;
   if hills[i].highway == true then
@@ -1095,19 +1097,18 @@ pass_note = function(i,j,seg,note_val,index,retrig_index)
   else
     played_note = get_random_offset(i,midi_notes[note_val])
   end
-  -- print(note_val, played_note)
   local _active = track[i][j]
+  local _page = _active.page
+  local _a = _active[_page]
   local focused_set;
   if hills[i].highway == true then
-    focused_set = _active.focus == 'main' and _active or _active.fill
+    focused_set = _active.focus == 'main' and _a or _a.fill
   end
   if (played_note ~= nil and hills[i].highway == false and hills[i][j].note_num.active[index]) or
     (played_note ~= nil and hills[i].highway == true and not focused_set.muted_trigs[index]) then
     -- per-step params //
     if i <= number_of_hills then
-      -- print(i,j,index,check_subtables(i,j,index),retrig_index)
       if check_subtables(i,j,index) then
-        -- tab.print(per_step_params_adjusted[i].param)
         -- step to step params resets:
         local target_trig;
         if hills[i].highway == true then
@@ -1124,26 +1125,20 @@ pass_note = function(i,j,seg,note_val,index,retrig_index)
             local check_prm = per_step_params_adjusted[i].param[k]
             print('>S>S>S'..check_prm)
             if _fkprm.adjusted_params[i][j][index].params[check_prm] == nil then
-              local lock_trig = track[i][j].focus == 'main' and track[i][j].lock_trigs[index] or track[i][j].fill.lock_trigs[index]
+              local lock_trig = track[i][j].focus == 'main' and track[i][j][_page].lock_trigs[index] or track[i][j][_page].fill.lock_trigs[index]
               local is_drum_voice = params.lookup[check_prm] <= last_voice_param
               local id = check_prm
               if is_drum_voice and i <= number_of_hills then
-                -- local target_voice = string.match(params:get_id(id),"%d+")
                 local target_voice = string.match(id,"%d+")
-                -- local target_drum = params:get_id(id):match('(.*_)')
                 local target_drum = id:match('(.*_)')
                 target_drum = string.gsub(target_drum, target_voice..'_', '')
                 target_drum = string.gsub(target_drum, '_', '')
-                -- local p_name = string.gsub(params:get_id(id),target_voice..'_'..target_drum..'_','')
                 local p_name = string.gsub(id,target_voice..'_'..target_drum..'_','')
                 prms.send_to_engine(target_voice,p_name,params:get(id))
                 print('reseeding non-adjusted value for voice', target_voice, j, index, id, p_name)
               else
-                -- local p_name = extract_voice_from_string(params:get_id(id))
                 local p_name = extract_voice_from_string(id)
-                -- local sc_target = string.gsub(params:get_id(id),p_name..'_','')
                 local sc_target = string.gsub(id,p_name..'_','')
-                -- print('reseeding non-adjusted value for fx', i, j, index, id)
                 engine['set_'..p_name..'_param'](sc_target,params:get(id))
               end
             end
@@ -1153,8 +1148,7 @@ pass_note = function(i,j,seg,note_val,index,retrig_index)
         -- this step's entry handling:
         -- per_step_params_adjusted[i] = {param = {}, value = {}}
         -- for k,v in next,_fkprm.adjusted_params[i][j][index].params do
-        for k,v in next,target_trig[i][j][index].params do
-          -- local is_drum_voice = k <= last_voice_param
+        for k,v in next,target_trig[i][j][_page][index].params do
           print('this is ahppening!!')
           local param_id = k
           print(k, last_voice_param)
@@ -1189,8 +1183,6 @@ pass_note = function(i,j,seg,note_val,index,retrig_index)
           per_step_params_adjusted[i].value[#per_step_params_adjusted[i].value+1] = v
         
         end
-
-        -- print(i,j,index)
       else
         -- restore default param value:
         for k = 1,#per_step_params_adjusted[i].param do
@@ -1210,7 +1202,7 @@ pass_note = function(i,j,seg,note_val,index,retrig_index)
       and hills[i][j].note_velocity[index]
       or (focused_set.velocities[index] * (focused_set.accented_trigs[index] and accent_vel or 1))
     if hills[i].highway then
-      local lock_trig = track[i][j].focus == 'main' and track[i][j].lock_trigs[index] or track[i][j].fill.lock_trigs[index]
+      local lock_trig = track[i][j].focus == 'main' and track[i][j][_page].lock_trigs[index] or track[i][j][_page].fill.lock_trigs[index]
       if focused_set.trigs[index] and not focused_set.muted_trigs[index] then
         if retrig_index == nil then
           if params:string('voice_model_'..i) ~= 'sample' then

--- a/hills.lua
+++ b/hills.lua
@@ -68,10 +68,6 @@ hill_names = {
 }
 
 number_of_step_pages = 8
-steps_min_max = {}
-for i = 1,number_of_step_pages do
-  steps_min_max[i] = {1+(16 * (i-1)), (16 * i)}
-end
 
 pre_step_page = 'play'
 

--- a/lib/ccparams.lua
+++ b/lib/ccparams.lua
@@ -200,18 +200,18 @@ function m:force(index, voice, alloc)
 end
 
 function m:unpack_pad(voice,pad)
-  for i = 6,#kildare_drum_params.sample do
-    if kildare_drum_params.sample[i].type ~= 'separator' then
-      local id = voice..'_sample_'..kildare_drum_params.sample[i].id
-      params:lookup_param(id):bang()
-      -- TODO: this doesn't respect polyphony...
-    end
-  end
-  print(voice, pad)
-  for prm,val in pairs(m.adjusted_params[voice][pad].params) do
-    -- print(prm,val)
-    params:lookup_param(prm).action(params:lookup_param(prm):map_value(val))
-  end
+  print("230520: WHEN DOES THIS HAPPEN? UNCOMMENT IF IT DOES")
+  -- for i = 6,#kildare_drum_params.sample do
+  --   if kildare_drum_params.sample[i].type ~= 'separator' then
+  --     local id = voice..'_sample_'..kildare_drum_params.sample[i].id
+  --     params:lookup_param(id):bang()
+  --     -- TODO: this doesn't respect polyphony...
+  --   end
+  -- end
+  -- print(voice, pad)
+  -- for prm,val in pairs(m.adjusted_params[voice][pad].params) do
+  --   params:lookup_param(prm).action(params:lookup_param(prm):map_value(val))
+  -- end
 end
 
 function m:delta(index, d, voice, alloc)

--- a/lib/enc_actions.lua
+++ b/lib/enc_actions.lua
@@ -1,8 +1,21 @@
 local enc_actions = {}
 
 function enc_actions.delta_track_pos(i,j,d)
-  track[i][j].ui_position = util.clamp(track[i][j].ui_position + d, 1, 128)
-  highway_ui.seq_page[i] = math.ceil(track[i][j].ui_position/16)
+  if track[i][j].ui_position + d < 1 then
+    local pre_change = highway_ui.seq_page[i]
+    highway_ui.seq_page[i] = util.clamp(highway_ui.seq_page[i]-1,1,8)
+    if pre_change ~= highway_ui.seq_page[i] then
+      track[i][j].ui_position = 16
+    end
+  elseif track[i][j].ui_position + d > 16 then
+    local pre_change = highway_ui.seq_page[i]
+    highway_ui.seq_page[i] = util.clamp(highway_ui.seq_page[i]+1,1,8)
+    if pre_change ~= highway_ui.seq_page[i] then
+      track[i][j].ui_position = 1
+    end
+  else
+    track[i][j].ui_position = util.clamp(track[i][j].ui_position + d, 1, 16)
+  end
 end
 
 local function check_for_menu_condition(i)

--- a/lib/enc_actions.lua
+++ b/lib/enc_actions.lua
@@ -244,7 +244,7 @@ function enc_actions.parse(n,d)
               end
             elseif ui.control_set == 'play' then
               hills[i].screen_focus = util.clamp(j+d,1,#track[i])
-              highway_ui.seq_page[i] = math.ceil(track[i][hills[i].screen_focus].ui_position/16)
+              -- highway_ui.seq_page[i] = math.ceil(track[i][hills[i].screen_focus].ui_position/16)
               if mods["hill"] then
                 grid_dirty = true
               end

--- a/lib/enc_actions.lua
+++ b/lib/enc_actions.lua
@@ -51,11 +51,6 @@ function enc_actions.parse(n,d)
         if hills[i].highway and key1_hold then
           enc_actions.delta_track_pos(i,j,d)
         else
-          -- hills[i].screen_focus = util.clamp(j+d,1,8)
-          -- if mods["hill"] then
-          --   grid_dirty = true
-          -- end
-          -- highway_ui.seq_page[i] = math.ceil(track[i][hills[i].screen_focus].ui_position/32)
           ui.hill_focus = util.clamp(ui.hill_focus+d,1,number_of_hills)
           if ui.hill_focus < 8 then
             if ui.menu_focus == 5 then
@@ -235,22 +230,21 @@ function enc_actions.parse(n,d)
                 end
               else
                 local _active = track[i][j]
-                local focused_set = _active.focus == 'main' and _active or _active.fill
+                local _a = _active[highway_ui.seq_page[i]]
+                local focused_set = _active.focus == 'main' and _a or _a.fill
                 if d > 0 then
                   if focused_set.trigs[_pos] == false then
-                    -- focused_set.trigs[_pos] = true
-                    _htracks.change_trig_state(focused_set,_pos,true,i,j)
+                    _htracks.change_trig_state(focused_set,_pos,true,i,j,highway_ui.seq_page[i])
                   end
                 else
                   if focused_set.trigs[_pos] == true then
-                    -- focused_set.trigs[_pos] = false
-                    _htracks.change_trig_state(focused_set,_pos,false,i,j)
+                    _htracks.change_trig_state(focused_set,_pos,false,i,j,highway_ui.seq_page[i])
                   end
                 end
               end
             elseif ui.control_set == 'play' then
               hills[i].screen_focus = util.clamp(j+d,1,#track[i])
-              highway_ui.seq_page[i] = math.ceil(track[i][hills[i].screen_focus].ui_position/32)
+              highway_ui.seq_page[i] = math.ceil(track[i][hills[i].screen_focus].ui_position/16)
               if mods["hill"] then
                 grid_dirty = true
               end
@@ -265,10 +259,11 @@ function enc_actions.parse(n,d)
                 _hsteps.cycle_er_param('shift',i,j,d)
               end
             else
+              local _page = track[i][j].page
               if s_c["bounds"]["focus"] == 1 then
-                track[i][j].start_point = util.clamp(track[i][j].start_point + d, 1, track[i][j].end_point)
+                track[i][j][_page].start_point = util.clamp(track[i][j][_page].start_point + d, 1, track[i][j][_page].end_point)
               elseif s_c["bounds"]["focus"] == 2 then
-                track[i][j].end_point = util.clamp(track[i][j].end_point + d, track[i][j].start_point, 128)
+                track[i][j][_page].end_point = util.clamp(track[i][j][_page].end_point + d, track[i][j][_page].start_point, 16)
               end
             end
           elseif ui.menu_focus == 3 and ui.control_set == 'edit' then
@@ -278,7 +273,7 @@ function enc_actions.parse(n,d)
                 _hsteps.cycle_chord_degrees(i,j,_pos,d)
               end
             else
-              _t.track_transpose(i,j,track[i][j].ui_position,d)
+              _t.track_transpose(i,j,highway_ui.seq_page[i],track[i][j].ui_position,d)
             end
           end
         end

--- a/lib/fkprm.lua
+++ b/lib/fkprm.lua
@@ -24,6 +24,7 @@ end
 m.flip_to_fkprm = function(prev_page, locked_entry)
   if ui.menu_focus == 1 or ui.menu_focus == 3 then
     m.voice_focus = ui.hill_focus
+    m.page_focus = highway_ui.seq_page[m.voice_focus]
     m.hill_focus = hills[m.voice_focus].screen_focus
     if hills[m.voice_focus].highway then
       if not locked_entry then
@@ -93,11 +94,11 @@ m.key = function(n,z)
     end
   elseif n==3 and z==1 and key1_hold then
     if m.alt_menu_focus == 1 or m.alt_menu_focus == 4 then
-      m:clear(params:lookup_param(page[m.pos+1]).id, m.voice_focus, m.hill_focus, m.step_focus, m.alt_menu_focus == 1 and '' or 'all')
+      m:clear(params:lookup_param(page[m.pos+1]).id, m.voice_focus, m.hill_focus, m.page_focus, m.step_focus, m.alt_menu_focus == 1 and '' or 'all')
     elseif m.alt_menu_focus == 2 or m.alt_menu_focus == 5 then
-      m:force(params:lookup_param(page[m.pos+1]).id, m.voice_focus, m.hill_focus, m.step_focus, m.alt_menu_focus == 2 and '' or 'all')
+      m:force(params:lookup_param(page[m.pos+1]).id, m.voice_focus, m.hill_focus, m.page_focus, m.step_focus, m.alt_menu_focus == 2 and '' or 'all')
     elseif m.alt_menu_focus == 3 or m.alt_menu_focus == 6 then
-      m:random(params:lookup_param(page[m.pos+1]).id, m.voice_focus, m.hill_focus, m.step_focus, m.alt_menu_focus == 3 and '' or 'all')
+      m:random(params:lookup_param(page[m.pos+1]).id, m.voice_focus, m.hill_focus, m.page_focus, m.step_focus, m.alt_menu_focus == 3 and '' or 'all')
     end
   elseif n==3 and z==1 then
     if t == params.tGROUP then
@@ -138,10 +139,10 @@ m.enc = function(n,d)
         local dx = m.fine and (d/20) or d
         if grid_data_entry then
           -- m:delta_many(page[m.pos+1], dx, m.voice_focus, m.hill_focus)
-          m:delta_many(params:lookup_param(page[m.pos+1]).id, dx, m.voice_focus, m.hill_focus)
+          m:delta_many(params:lookup_param(page[m.pos+1]).id, dx, m.voice_focus, m.hill_focus, m.page_focus)
         else
           -- m:delta(page[m.pos+1], dx, m.voice_focus, m.hill_focus, m.step_focus)
-          m:delta(params:lookup_param(page[m.pos+1]).id, dx, m.voice_focus, m.hill_focus, m.step_focus)
+          m:delta(params:lookup_param(page[m.pos+1]).id, dx, m.voice_focus, m.hill_focus, m.page_focus, m.step_focus)
         end
         m.redraw()
       end
@@ -179,8 +180,8 @@ function m:clear(index, voice, hill, page, step, mode)
   if mode == 'all' then
     for i = track[voice][hill][page].start_point, track[voice][hill][page].end_point do
       local target_trig = get_focus(voice,hill,page,i)
-      target_trig[voice][hill][i][page].params[index] = nil
-      if tab.count(target_trig[voice][hill][i][page].params) == 0 then
+      target_trig[voice][hill][page][i].params[index] = nil
+      if tab.count(target_trig[voice][hill][page][i].params) == 0 then
         track[voice][hill][page].lock_trigs[i] = false
       end
     end
@@ -289,7 +290,6 @@ function m:map(p)
   else
     target_trig = self.adjusted_params[self.voice_focus][self.hill_focus][self.page_focus][self.step_focus]
   end
-  -- local value = target_trig[self.voice_focus][self.hill_focus][self.step_focus].params[p]
   local value = target_trig.params[params:lookup_param(p).id]
   local clamped = util.clamp(value, 0, 1)
   local cs = params:lookup_param(p).controlspec
@@ -311,7 +311,7 @@ function m:string(p)
     else
       target_trig = self.adjusted_params
     end
-    local value = target_trig[self.voice_focus][self.hill_focus][self.step_focus].params[p]
+    local value = target_trig[self.voice_focus][self.hill_focus][sel.page_focus][self.step_focus].params[p]
     local a = util.round(value, 0.01)
     return a.." "..params:lookup_param(p).controlspec.units
   end
@@ -328,9 +328,8 @@ local function prm_lookup(t, ...)
 end
 
 local function check_subtables(p)
-  local target_trig = get_focus(m.voice_focus,m.hill_focus,m.step_focus)
-  -- return prm_lookup(target_trig, m.voice_focus,m.hill_focus,m.step_focus,'params',p)
-  return prm_lookup(target_trig, m.voice_focus,m.hill_focus,m.step_focus,'params',params:lookup_param(p).id)
+  local target_trig = get_focus(m.voice_focus,m.hill_focus,m.page_focus,m.step_focus)
+  return prm_lookup(target_trig, m.voice_focus,m.hill_focus,m.page_focus,m.step_focus,'params',params:lookup_param(p).id)
 end
 
 m.redraw = function()

--- a/lib/fkprm.lua
+++ b/lib/fkprm.lua
@@ -279,17 +279,18 @@ end
 --- UP TO HERE...230519
 function m:map(p)
   local target_trig;
+  local focused_step = track[self.voice_focus][self.hill_focus][self.page_focus].trigs[self.step_focus]
   if hills[self.voice_focus].highway == true then
-    if track[self.voice_focus][self.hill_focus].trigs[self.step_focus] then
-      target_trig = self.adjusted_params
+    if focused_step then
+      target_trig = self.adjusted_params[self.voice_focus][self.hill_focus][self.page_focus][self.step_focus]
     else
-      target_trig = self.adjusted_params_lock_trigs
+      target_trig = self.adjusted_params_lock_trigs[self.voice_focus][self.hill_focus][self.page_focus][self.step_focus]
     end
   else
-    target_trig = self.adjusted_params
+    target_trig = self.adjusted_params[self.voice_focus][self.hill_focus][self.page_focus][self.step_focus]
   end
   -- local value = target_trig[self.voice_focus][self.hill_focus][self.step_focus].params[p]
-  local value = target_trig[self.voice_focus][self.hill_focus][self.step_focus].params[params:lookup_param(p).id]
+  local value = target_trig.params[params:lookup_param(p).id]
   local clamped = util.clamp(value, 0, 1)
   local cs = params:lookup_param(p).controlspec
   local rounded = util.round(cs.warp.map(cs, clamped), cs.step)
@@ -302,7 +303,7 @@ function m:string(p)
   else
     local target_trig;
     if hills[self.voice_focus].highway == true then
-      if track[self.voice_focus][self.hill_focus].trigs[self.step_focus] then
+      if track[self.voice_focus][self.hill_focus][self.page_focus].trigs[self.step_focus] then
         target_trig = self.adjusted_params
       else
         target_trig = self.adjusted_params_lock_trigs
@@ -336,7 +337,7 @@ m.redraw = function()
   -- print(m.pos, 2 - m.pos, #page - m.pos + 3)
   screen.clear()
   screen.font_size(8)
-  local trig_type = track[m.voice_focus][m.hill_focus].trigs[m.step_focus] and '' or ' (parameter lock)'
+  local trig_type = track[m.voice_focus][m.hill_focus][m.page_focus].trigs[m.step_focus] and '' or ' (parameter lock)'
   local n = m.voice_focus..' / hill: '..m.hill_focus..trig_type
   screen.level(4)
   screen.move(0,10)

--- a/lib/grid_lib.lua
+++ b/lib/grid_lib.lua
@@ -943,7 +943,6 @@ function grid_lib.highway_press(x,y,z)
       and not grid_accent
       and not grid_mute then
         track[i][j].ui_position = pressed_step
-        print('here')
         _htracks.change_trig_state(focused_set,pressed_step, not (focused_set.trigs[pressed_step]), i, j, _page)
         for k = 1,16 do
           local table_to_record =

--- a/lib/grid_lib.lua
+++ b/lib/grid_lib.lua
@@ -1584,7 +1584,7 @@ function grid_lib.draw_highway()
   -- draw steps + sequence selector
   local lvl = 5
   local flipped_entry_steps = tab.invert(grid_data_entry and data_entry_steps.focus[i] or conditional_entry_steps.focus[i])
-  for display_step = steps_min_max[_hui.seq_page[i]][1], steps_min_max[_hui.seq_page[i]][2] do
+  for display_step = 1,16 do
     if grid_loop_modifier then
       if display_step == _active.end_point or display_step == _active.start_point then
         if loop_modifier_stage == 'define start' and display_step == _active.start_point then

--- a/lib/grid_lib.lua
+++ b/lib/grid_lib.lua
@@ -989,15 +989,15 @@ function grid_lib.highway_press(x,y,z)
       end
     end
   -- grid lock mode:
-  elseif (y == 5 or y == 6) and (x >=5 and x <= 8) then
-    highway_ui.seq_page[i] = x-4 + (y == 5 and 0 or 4)
-    -- track[i][j].ui_position = ((highway_ui.seq_page[i] - 1) * 16) + 1
-  elseif y <= 6 and z == 0 and (x >= 1 and x <= 8) then
+  elseif y <= 4 and z == 0 and (x >= 1 and x <= 8) then
     if grid_conditional_entry then
       conditional_entry_steps.held[i] = util.clamp(conditional_entry_steps.held[i] - 1,0,128)
     elseif grid_data_entry then
       data_entry_steps.held[i] = util.clamp(data_entry_steps.held[i] - 1,0,128)
     end
+  elseif (y == 5 or y == 6) and (x >=5 and x <= 8) then
+    highway_ui.seq_page[i] = x-4 + (y == 5 and 0 or 4)
+    -- track[i][j].ui_position = ((highway_ui.seq_page[i] - 1) * 16) + 1
   elseif y == 7 and x == 1 then
     highway_mod_copy.state = z == 1
   elseif y == 5 and x == 1 then
@@ -1682,7 +1682,7 @@ function grid_lib.draw_highway()
       lvl = 10
     else
       if _active.playing then
-        if math.ceil(_active.step/16) == j then
+        if _active.page == j then
           lvl = 5
         else
           lvl = 2

--- a/lib/highway_steps.lua
+++ b/lib/highway_steps.lua
@@ -336,11 +336,7 @@ function hway_ui.draw_menu()
           base = focused_set.conditional.mode[current_step]
           line_above = false
         end
-        if base == nil then
-          print(focused_set)
-        else
-          screen.text('COND: '..base)
-        end
+        screen.text('COND: '..base)
         if line_above then
           -- screen.move(87,14)
           screen.move(57,36)

--- a/lib/highway_steps.lua
+++ b/lib/highway_steps.lua
@@ -32,7 +32,9 @@ function hway_ui.draw_menu()
 
   local hf = ui.hill_focus
   local h = hills[hf]
+  local _page = highway_ui.seq_page[hf]
   local _active = track[hf][h.screen_focus]
+  local _a = track[hf][h.screen_focus][_page]
   screen.level(15)
   screen.move(0,10)
   screen.aa(1)
@@ -84,7 +86,7 @@ function hway_ui.draw_menu()
         end
       end
 
-      local focused_set = _active.focus == "main" and _active or _active.fill
+      local focused_set = _active.focus == "main" and _a or _a.fill
       screen.move(0,10)
       screen.level(3)
       screen.level(_hui.focus == "seq" and 8 or 0)
@@ -93,7 +95,7 @@ function hway_ui.draw_menu()
       screen.fill()
       local lvl = 5
       screen.font_face(2)
-      for i = steps_min_max[_hui.seq_page[hf]][1], steps_min_max[_hui.seq_page[hf]][2] do
+      for i = 1,16 do
         if e_pos == i then
           if _active.step == i and _active.playing then
             lvl = _hui.focus == "seq" and 5 or 4
@@ -101,7 +103,7 @@ function hway_ui.draw_menu()
             lvl = _hui.focus == "seq" and 0 or 2
           end
         else
-          if i <= _active.end_point and i >= _active.start_point then
+          if i <= _a.end_point and i >= _a.start_point then
             if _active.step == i then
               lvl = _hui.focus == "seq" and 15 or 4
             else
@@ -248,9 +250,6 @@ function hway_ui.draw_menu()
           screen.rect(113 + (util.wrap(i-1,0,3) * 4),i <= 4 and 56 or 60,3,3)
           screen.fill()
         end
-        -- screen.move(128,64)
-        -- screen.level(3)
-        -- screen.text_right(track[hf][h.screen_focus].ui_position..' / '..steps_min_max[_hui.seq_page[hf]][1]..'-'..steps_min_max[_hui.seq_page[hf]][2])
       end
 
       if ui.menu_focus == 1 then
@@ -287,10 +286,9 @@ function hway_ui.draw_menu()
         screen.text_right("max: "..track[hf][h.screen_focus].end_point)
       elseif ui.menu_focus == 3 then
         if ui.control_set == 'edit' then
-          local _active = track[hf][h.screen_focus]
           local pos = _active.ui_position
           local display_text = ''
-          local focused_set = _active.focus == "main" and _active or _active.fill
+          local focused_set = _active.focus == "main" and _a or _a.fill
           screen.level(3)
           if focused_set.trigs[pos] == false then
             display_text = 'set note adds trig'
@@ -353,7 +351,7 @@ function hway_ui.draw_menu()
         screen.level(_s.popup_focus.tracks[hf][1] == 3 and lvl_sel or lvl_other)
         screen.text('RETRIG: '..focused_set.conditional.retrig_count[current_step]..'x')
         screen.level(_s.popup_focus.tracks[hf][1] == 4 and lvl_sel or lvl_other)
-        local get_string = _active.focus == 'main' and ('track_retrig_time_'..hf..'_'..h.screen_focus..'_'..current_step) or ('track_fill_retrig_time_'..hf..'_'..h.screen_focus..'_'..current_step)
+        local get_string = _active.focus == 'main' and ('track_retrig_time_'..hf..'_'..h.screen_focus..'_'.._page..'_'..current_step) or ('track_fill_retrig_time_'..hf..'_'..h.screen_focus..'_'.._page..'_'..current_step)
         screen.move(84,52)
         screen.text('RATE: '..track_paramset:string(get_string))
         screen.level(_s.popup_focus.tracks[hf][1] == 5 and lvl_sel or lvl_other)
@@ -524,24 +522,6 @@ function hway_ui.cycle_chord_degrees(i,j,step,d)
   local _active = track[i][j]
   local focused_set = _active.focus == 'main' and _active or _active.fill
   focused_set.chord_degrees[step] = util.clamp(focused_set.chord_degrees[step] + d, 1, 7)
-end
-
-function hway_ui.check_for_first_touch()
-  -- local _active = track[_hui.sel][track[_hui.sel].active_hill]
-  local hf = ui.hill_focus
-  local h = hills[hf]
-  local _active = track[hf][h.screen_focus]
-  local focused_set = _active.focus == "main" and track[_hui.sel] or _active.fill
-  if tab.count(focused_set.base_note) == 1
-  and not _active.playing
-  and not _active.pause
-  and not _active.enabled
-  then
-    step.enable(_hui.sel,true)
-    _active.pause = true
-    _active.hold = true
-    grid_dirty = true
-  end
 end
 
 function hway_ui.index_to_grid_pos(val,columns)

--- a/lib/highway_steps.lua
+++ b/lib/highway_steps.lua
@@ -97,14 +97,14 @@ function hway_ui.draw_menu()
       screen.font_face(2)
       for i = 1,16 do
         if e_pos == i then
-          if _active.step == i and _active.playing then
+          if _active.step == i and _active.playing and highway_ui.seq_page[hf] == _active.page then
             lvl = _hui.focus == "seq" and 5 or 4
           else
             lvl = _hui.focus == "seq" and 0 or 2
           end
         else
           if i <= _a.end_point and i >= _a.start_point then
-            if _active.step == i then
+            if _active.step == i and highway_ui.seq_page[hf] == _active.page then
               lvl = _hui.focus == "seq" and 15 or 4
             else
               lvl = _hui.focus == "seq" and 5 or 2
@@ -276,19 +276,18 @@ function hway_ui.draw_menu()
           screen.level(s_c["bounds"]["focus"] == 1 and 15 or 3)
         end
         screen.move(32,10)
-        screen.text("min: "..track[hf][h.screen_focus].start_point)
+        screen.text("min: "..track[hf][h.screen_focus][_page].start_point)
         if ui.control_set == 'play' then
           screen.level(3)
         else
           screen.level(s_c["bounds"]["focus"] == 1 and 3 or 15)
         end
         screen.move(128,10)
-        screen.text_right("max: "..track[hf][h.screen_focus].end_point)
+        screen.text_right("max: "..track[hf][h.screen_focus][_page].end_point)
       elseif ui.menu_focus == 3 then
         if ui.control_set == 'edit' then
           local pos = _active.ui_position
           local display_text = ''
-          local focused_set = _active.focus == "main" and _a or _a.fill
           screen.level(3)
           if focused_set.trigs[pos] == false then
             display_text = 'set note adds trig'
@@ -337,7 +336,11 @@ function hway_ui.draw_menu()
           base = focused_set.conditional.mode[current_step]
           line_above = false
         end
-        screen.text('COND: '..base)
+        if base == nil then
+          print(focused_set)
+        else
+          screen.text('COND: '..base)
+        end
         if line_above then
           -- screen.move(87,14)
           screen.move(57,36)
@@ -414,11 +417,12 @@ local conditional_modes = {"NOT NEI","NEI","NOT PRE","PRE","A:B"}
 
 function hway_ui.cycle_conditional(i,j,step,d)
   local _active = track[i][j]
+  local _a = _active[_active.page]
   local send_to_many = false
   if grid_conditional_entry and #conditional_entry_steps.focus[i] > 1 then
     step = conditional_entry_steps.focus[i][#conditional_entry_steps.focus[i]]
   end
-  local focused_set = _active.focus == 'main' and _active or _active.fill
+  local focused_set = _active.focus == 'main' and _a or _a.fill
   if d > 0 then
     if focused_set.conditional.mode[step] == "A:B" then
       local current_B = focused_set.conditional.B[step]
@@ -478,7 +482,8 @@ end
 
 function hway_ui.cycle_prob(i,j,step,d)
   local _active = track[i][j]
-  local focused_set = _active.focus == 'main' and _active or _active.fill
+  local _a = _active[_active.page]
+  local focused_set = _active.focus == 'main' and _a or _a.fill
   if grid_conditional_entry and #conditional_entry_steps.focus[i] > 1 then
     step = conditional_entry_steps.focus[i][#conditional_entry_steps.focus[i]]
   end
@@ -490,25 +495,28 @@ end
 
 function hway_ui.cycle_retrig_count(i,j,step,d)
   local _active = track[i][j]
-  local focused_set = _active.focus == 'main' and _active or _active.fill
+  local _a = _active[_active.page]
+  local focused_set = _active.focus == 'main' and _a or _a.fill
   focused_set.conditional.retrig_count[step] = util.clamp(focused_set.conditional.retrig_count[step]+d, 0, 128)
 end
 
 function hway_ui.cycle_retrig_time(i,j,step,d)
   local _active = track[i][j]
-  local focused_set = _active.focus == 'main' and ('track_retrig_time_'..i..'_'..j..'_'..step) or ('track_fill_retrig_time_'..i..'_'..j..'_'..step)
+  local focused_set = _active.focus == 'main' and ('track_retrig_time_'..i..'_'..j..'_'.._active.page..'_'..step) or ('track_fill_retrig_time_'..i..'_'..j..'_'.._active.page..'_'..step)
   track_paramset:delta(focused_set,d)
 end
 
 function hway_ui.cycle_retrig_vel(i,j,step,d)
   local _active = track[i][j]
-  local focused_set = _active.focus == 'main' and _active or _active.fill
+  local _a = _active[_active.page]
+  local focused_set = _active.focus == 'main' and _a or _a.fill
   focused_set.conditional.retrig_slope[step] = util.clamp(focused_set.conditional.retrig_slope[step]+d, -128, 128)
 end
 
 function hway_ui.cycle_er_param(prm,i,j,d)
   local _active = track[i][j]
-  local focused_set = _active.focus == 'main' and _active or _active.fill
+  local _a = _active[_active.page]
+  local focused_set = _active.focus == 'main' and _a or _a.fill
   if prm == 'pulses' then
     focused_set.er[prm] = util.clamp(focused_set.er[prm] + d, 0, focused_set.er.steps)
   elseif prm == 'steps' then
@@ -520,7 +528,8 @@ end
 
 function hway_ui.cycle_chord_degrees(i,j,step,d)
   local _active = track[i][j]
-  local focused_set = _active.focus == 'main' and _active or _active.fill
+  local _a = _active[_active.page]
+  local focused_set = _active.focus == 'main' and _a or _a.fill
   focused_set.chord_degrees[step] = util.clamp(focused_set.chord_degrees[step] + d, 1, 7)
 end
 

--- a/lib/highway_steps.lua
+++ b/lib/highway_steps.lua
@@ -413,7 +413,7 @@ local conditional_modes = {"NOT NEI","NEI","NOT PRE","PRE","A:B"}
 
 function hway_ui.cycle_conditional(i,j,step,d)
   local _active = track[i][j]
-  local _a = _active[_active.page]
+  local _a = _active[highway_ui.seq_page[i]] -- here, we want the UI page, not the tracked page
   local send_to_many = false
   if grid_conditional_entry and #conditional_entry_steps.focus[i] > 1 then
     step = conditional_entry_steps.focus[i][#conditional_entry_steps.focus[i]]
@@ -478,7 +478,7 @@ end
 
 function hway_ui.cycle_prob(i,j,step,d)
   local _active = track[i][j]
-  local _a = _active[_active.page]
+  local _a = _active[highway_ui.seq_page[i]]
   local focused_set = _active.focus == 'main' and _a or _a.fill
   if grid_conditional_entry and #conditional_entry_steps.focus[i] > 1 then
     step = conditional_entry_steps.focus[i][#conditional_entry_steps.focus[i]]
@@ -491,7 +491,7 @@ end
 
 function hway_ui.cycle_retrig_count(i,j,step,d)
   local _active = track[i][j]
-  local _a = _active[_active.page]
+  local _a = _active[highway_ui.seq_page[i]]
   local focused_set = _active.focus == 'main' and _a or _a.fill
   focused_set.conditional.retrig_count[step] = util.clamp(focused_set.conditional.retrig_count[step]+d, 0, 128)
 end
@@ -504,14 +504,14 @@ end
 
 function hway_ui.cycle_retrig_vel(i,j,step,d)
   local _active = track[i][j]
-  local _a = _active[_active.page]
+  local _a = _active[highway_ui.seq_page[i]]
   local focused_set = _active.focus == 'main' and _a or _a.fill
   focused_set.conditional.retrig_slope[step] = util.clamp(focused_set.conditional.retrig_slope[step]+d, -128, 128)
 end
 
 function hway_ui.cycle_er_param(prm,i,j,d)
   local _active = track[i][j]
-  local _a = _active[_active.page]
+  local _a = _active[highway_ui.seq_page[i]]
   local focused_set = _active.focus == 'main' and _a or _a.fill
   if prm == 'pulses' then
     focused_set.er[prm] = util.clamp(focused_set.er[prm] + d, 0, focused_set.er.steps)
@@ -524,7 +524,7 @@ end
 
 function hway_ui.cycle_chord_degrees(i,j,step,d)
   local _active = track[i][j]
-  local _a = _active[_active.page]
+  local _a = _active[highway_ui.seq_page[i]]
   local focused_set = _active.focus == 'main' and _a or _a.fill
   focused_set.chord_degrees[step] = util.clamp(focused_set.chord_degrees[step] + d, 1, 7)
 end

--- a/lib/highway_tracks.lua
+++ b/lib/highway_tracks.lua
@@ -200,6 +200,16 @@ function track_actions.init(target, hill_number, clear_reset)
     false,
     false
   }
+  track[target][hill_number].page_probability = {
+    100,
+    100,
+    100,
+    100,
+    100,
+    100,
+    100,
+    100
+  }
   track[target][hill_number].swing = 50
   track[target][hill_number].mode = "fwd"
   track[target][hill_number].loop = true
@@ -317,14 +327,37 @@ function track_actions.change_pattern(i,j,source)
   track_actions.start_playback(i,j)
 end
 
+function track_actions.check_page_probability(n,i,j)
+  local _page = track[i][j].page
+  if math.random(0,100) <= track[i][j].page_probability[n] then
+    if i == 1 then
+      print("page "..n)
+    end
+    return n
+  else
+    if i == 1 then
+      print("skip page "..n)
+    end
+    return track[i][j].page_chain()
+  end
+end
+
+function track_actions.change_page_probability(i,j,d)
+  track[i][j].page_probability = util.clamp(track[i][j].page_probability+d,0,100)
+  track[i][j].page_chain:map(track_actions.check_page_probability,i,j)
+end
+
 function track_actions.start_playback(i,j)
   local _page;
-  for p = 1,8 do
-    if track[i][j].page_active[p] then
-      _page = p
-      break
-    end
-  end
+  -- for p = 1,8 do
+  --   if track[i][j].page_active[p] then
+  --     _page = p
+  --     break
+  --   end
+  -- end
+  track[i][j].page_chain:map(track_actions.check_page_probability,i,j)
+  track[i][j].page_chain:reset()
+  _page = track[i][j].page_chain()
   track[i][j][_page].micro[0] = track[i][j][_page].micro[1]
   local track_start =
   {

--- a/lib/highway_tracks.lua
+++ b/lib/highway_tracks.lua
@@ -329,7 +329,7 @@ end
 
 function track_actions.check_page_probability(n,i,j)
   local _page = track[i][j].page
-  if math.random(0,100) <= track[i][j].page_probability[n] then
+  if math.random(1,100) <= track[i][j].page_probability[n] then
     if i == 1 then
       print("page "..n)
     end
@@ -342,8 +342,8 @@ function track_actions.check_page_probability(n,i,j)
   end
 end
 
-function track_actions.change_page_probability(i,j,d)
-  track[i][j].page_probability = util.clamp(track[i][j].page_probability+d,0,100)
+function track_actions.change_page_probability(i,j,n,d)
+  track[i][j].page_probability[n] = util.clamp(track[i][j].page_probability[n]+d,1,100)
   track[i][j].page_chain:map(track_actions.check_page_probability,i,j)
 end
 

--- a/lib/highway_tracks.lua
+++ b/lib/highway_tracks.lua
@@ -1,4 +1,5 @@
 local track_actions = {}
+local s = require 'sequins'
 
 track = {}
 
@@ -203,6 +204,7 @@ function track_actions.init(target, hill_number, clear_reset)
   track[target][hill_number].mode = "fwd"
   track[target][hill_number].loop = true
   track[target][hill_number].focus = "main"
+  track[target][hill_number].page_chain = s{1}
   
   for pages = 1,8 do
     track[target][hill_number][pages] = {}
@@ -408,6 +410,7 @@ function track_actions.tick(target) -- FIXME: shouldn't just trigger all voices 
   end
 end
 
+-- 230520 TODO: evaluate necessity of these (probably would be cool tho!):
 -- function track_actions.prob_fill(target,s_p,e_p,value)
 --   local _active = track[target][track[target].active_hill]
 --   local focused_set = _active.focus == "main" and _active or _active.fill
@@ -447,7 +450,7 @@ end
 -- end
 
 function track_actions.change_trig_state(target_track,target_step,state, i, j, _page)
-  print('change_trig_state:',target_track,target_step,state, _page)
+  -- print('change_trig_state:',target_track,target_step,state, _page)
   target_track.trigs[target_step] = state
   if state == true then
     if tab.count(_fkprm.adjusted_params_lock_trigs[i][j][_page][target_step].params) > 0 then
@@ -457,6 +460,7 @@ function track_actions.change_trig_state(target_track,target_step,state, i, j, _
 end
 
 function track_actions.copy(target,pattern)
+  -- 230520: TODO fix indexing for 'pages'
   local _active = track[target][pattern]
   if track_clipboard == nil then
     track_clipboard = _t.deep_copy(_active)
@@ -573,10 +577,20 @@ end
 function track_actions.forward(target)
   local _active = track[target][track[target].active_hill]
   local _a = _active[_active.page]
-  _active.step = wrap(_active.step + 1,_a.start_point,_a.end_point)
-  if _active.step == _a.start_point then
+  _active.step = _active.step + 1
+  if _active.step > _a.end_point then
+    _active.page = _active.page_chain()
+    _a = _active[_active.page]
+    _active.step = _a.start_point
     _a.conditional.cycle = _a.conditional.cycle + 1
+    -- if _active.step == _a.start_point then
+    --   _a.conditional.cycle = _a.conditional.cycle + 1
+    -- end
   end
+  -- _active.step = wrap(_active.step + 1,_a.start_point,_a.end_point)
+  -- if _active.step == _a.start_point then
+  --   _a.conditional.cycle = _a.conditional.cycle + 1
+  -- end
 end
 
 function track_actions.backward(target)

--- a/lib/highway_tracks.lua
+++ b/lib/highway_tracks.lua
@@ -66,8 +66,8 @@ local track_retrig_lookup =
   64
 }
 
-local function build_params(target, hill_number, i)
-  track_paramset:add_option("track_retrig_time_"..target.."_"..hill_number..'_'..i,"",
+local function build_params(target, hill_number, page_number, i)
+  track_paramset:add_option("track_retrig_time_"..target.."_"..hill_number..'_'..page_number..'_'..i,"",
     {
       '1/64',
       '1/48',
@@ -108,11 +108,11 @@ local function build_params(target, hill_number, i)
       '64'
     },
     13)
-  track_paramset:set_action("track_retrig_time_"..target.."_"..hill_number..'_'..i, function(x)
-    track[target][hill_number].conditional.retrig_time[i] = track_retrig_lookup[x]
+  track_paramset:set_action("track_retrig_time_"..target.."_"..hill_number..'_'..page_number..'_'..i, function(x)
+    track[target][hill_number][page_number].conditional.retrig_time[i] = track_retrig_lookup[x]
   end)
 
-  track_paramset:add_option("track_fill_retrig_time_"..target.."_"..hill_number..'_'..i,"",
+  track_paramset:add_option("track_fill_retrig_time_"..target.."_"..hill_number..'_'..page_number..'_'..i,"",
   {
     '1/64',
     '1/48',
@@ -153,8 +153,8 @@ local function build_params(target, hill_number, i)
     '64'
   },
   13)
-  track_paramset:set_action("track_fill_retrig_time_"..target.."_"..hill_number..'_'..i, function(x)
-    track[target][hill_number].fill.conditional.retrig_time[i] = track_retrig_lookup[x]
+  track_paramset:set_action("track_fill_retrig_time_"..target.."_"..hill_number..'_'..page_number..'_'..i, function(x)
+    track[target][hill_number][page_number].fill.conditional.retrig_time[i] = track_retrig_lookup[x]
   end)
 end
 
@@ -169,8 +169,7 @@ function track_actions.init(target, hill_number, clear_reset)
     track[target] = {}
     track[target].scale = {source = {}, index = 1}
     track[target].active_hill = 1
-    track[target].seed_prob = 100
-    track[target].song_mute = {}
+    -- track[target].song_mute = {}
     track[target].external_prm_change = {}
     track[target].rec = false
     track[target].rec_note_entry = false
@@ -182,8 +181,6 @@ function track_actions.init(target, hill_number, clear_reset)
   track[target][hill_number] = {}
   track[target][hill_number].playing = false
   track[target][hill_number].pause = false
-  track[target][hill_number].hold = false
-  track[target][hill_number].enabled = false
   track[target][hill_number].time = 1/4
   if not clear_reset or (clear_reset and track[target].active_hill ~= hill_number) then
     track[target][hill_number].step = 1
@@ -191,106 +188,116 @@ function track_actions.init(target, hill_number, clear_reset)
     track[target][hill_number].step = pre_clear_step
   end
   track[target][hill_number].ui_position = 1
-  track[target][hill_number].ui_page = 1
-  
-  track[target][hill_number].base_note = {}
-  track[target][hill_number].chord_notes = {}
-  track[target][hill_number].seed_default_note = {}
-  track[target][hill_number].chord_degrees = {}
-  track[target][hill_number].velocities = {}
-  track[target][hill_number].trigs = {}
-  track[target][hill_number].muted_trigs = {}
-  track[target][hill_number].accented_trigs = {}
-  track[target][hill_number].legato_trigs = {}
-  track[target][hill_number].lock_trigs = {}
-  track[target][hill_number].prob = {}
-  track[target][hill_number].micro = {}
-  track[target][hill_number].song_mute = false
-  track[target][hill_number].er = {pulses = 0, steps = 16, shift = 0}
-  track[target][hill_number].last_condition = false
-  track[target][hill_number].conditional = {}
-  track[target][hill_number].conditional.cycle = 1
-  track[target][hill_number].conditional.A = {}
-  track[target][hill_number].conditional.B = {}
-  track[target][hill_number].conditional.mode = {}
-  track[target][hill_number].conditional.retrig_clock = nil
-  track[target][hill_number].conditional.retrig_count = {}
-  track[target][hill_number].conditional.retrig_time = {}
-  track[target][hill_number].conditional.retrig_slope = {}
-  track[target][hill_number].focus = "main"
-  track[target][hill_number].fill =
-  {
-    ["base_note"] = {},
-    ["chord_notes"] = {},
-    ["seed_default_note"] = {},
-    ["chord_degrees"] = {},
-    ["velocities"] = {},
-    ["trigs"] = {},
-    ["muted_trigs"] = {},
-    ["accented_trigs"] = {},
-    ["legato_trigs"] = {},
-    ["lock_trigs"] = {},
-    ["prob"] = {},
-    ['er'] = {pulses = 0, steps = 16, shift = 0},
-    ["conditional"] = {
-      ["A"] = {},
-      ["B"] = {},
-      ["mode"] = {},
-      ["retrig_count"] = {},
-      ["retrig_time"] = {},
-      ["retrig_slope"] = {}
-    }
+  track[target][hill_number].page = 1
+  track[target][hill_number].page_active = {
+    true,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false
   }
-  for i = 1,128 do
-    track[target][hill_number].base_note[i] = -1
-    track[target][hill_number].chord_notes[i] = {0,0,0}
-    track[target][hill_number].seed_default_note[i] = true
-    track[target][hill_number].chord_degrees[i] = 1
-    track[target][hill_number].velocities[i] = 127
-    track[target][hill_number].trigs[i] = false
-    track[target][hill_number].muted_trigs[i] = false
-    track[target][hill_number].accented_trigs[i] = false
-    track[target][hill_number].legato_trigs[i] = false
-    track[target][hill_number].lock_trigs[i] = false
-    track[target][hill_number].prob[i] = 100
-    track[target][hill_number].conditional.A[i] = 1
-    track[target][hill_number].conditional.B[i] = 1
-    track[target][hill_number].conditional.mode[i] = "A:B"
-    track[target][hill_number].conditional.retrig_count[i] = 0
-    track[target][hill_number].micro[i] = 0
-    if not clear_reset then
-      build_params(target,hill_number,i)
+  
+  for pages = 1,8 do
+    track[target][hill_number][pages] = {}
+    track[target][hill_number][pages].base_note = {}
+    track[target][hill_number][pages].chord_notes = {}
+    track[target][hill_number][pages].seed_default_note = {}
+    track[target][hill_number][pages].chord_degrees = {}
+    track[target][hill_number][pages].velocities = {}
+    track[target][hill_number][pages].trigs = {}
+    track[target][hill_number][pages].muted_trigs = {}
+    track[target][hill_number][pages].accented_trigs = {}
+    track[target][hill_number][pages].legato_trigs = {}
+    track[target][hill_number][pages].lock_trigs = {}
+    track[target][hill_number][pages].prob = {}
+    track[target][hill_number][pages].micro = {}
+    track[target][hill_number][pages].er = {pulses = 0, steps = 16, shift = 0}
+    track[target][hill_number][pages].last_condition = false
+    track[target][hill_number][pages].conditional = {}
+    track[target][hill_number][pages].conditional.cycle = 1
+    track[target][hill_number][pages].conditional.A = {}
+    track[target][hill_number][pages].conditional.B = {}
+    track[target][hill_number][pages].conditional.mode = {}
+    track[target][hill_number][pages].conditional.retrig_clock = nil
+    track[target][hill_number][pages].conditional.retrig_count = {}
+    track[target][hill_number][pages].conditional.retrig_time = {}
+    track[target][hill_number][pages].conditional.retrig_slope = {}
+    track[target][hill_number][pages].focus = "main"
+    track[target][hill_number][pages].fill =
+    {
+      ["base_note"] = {},
+      ["chord_notes"] = {},
+      ["seed_default_note"] = {},
+      ["chord_degrees"] = {},
+      ["velocities"] = {},
+      ["trigs"] = {},
+      ["muted_trigs"] = {},
+      ["accented_trigs"] = {},
+      ["legato_trigs"] = {},
+      ["lock_trigs"] = {},
+      ["prob"] = {},
+      ['er'] = {pulses = 0, steps = 16, shift = 0},
+      ["conditional"] = {
+        ["A"] = {},
+        ["B"] = {},
+        ["mode"] = {},
+        ["retrig_count"] = {},
+        ["retrig_time"] = {},
+        ["retrig_slope"] = {}
+      }
+    }
+    for i = 1,16 do
+
+      track[target][hill_number][pages].start_point = 1
+      track[target][hill_number][pages].end_point = 16
+
+      track[target][hill_number][pages].base_note[i] = -1
+      track[target][hill_number][pages].chord_notes[i] = {0,0,0}
+      track[target][hill_number][pages].seed_default_note[i] = true
+      track[target][hill_number][pages].chord_degrees[i] = 1
+      track[target][hill_number][pages].velocities[i] = 127
+      track[target][hill_number][pages].trigs[i] = false
+      track[target][hill_number][pages].muted_trigs[i] = false
+      track[target][hill_number][pages].accented_trigs[i] = false
+      track[target][hill_number][pages].legato_trigs[i] = false
+      track[target][hill_number][pages].lock_trigs[i] = false
+      track[target][hill_number][pages].prob[i] = 100
+      track[target][hill_number][pages].conditional.A[i] = 1
+      track[target][hill_number][pages].conditional.B[i] = 1
+      track[target][hill_number][pages].conditional.mode[i] = "A:B"
+      track[target][hill_number][pages].conditional.retrig_count[i] = 0
+      track[target][hill_number][pages].micro[i] = 0
+      if not clear_reset then
+        build_params(target,hill_number,pages,i)
+      end
+      track[target][hill_number][pages].conditional.retrig_time[i] = track_retrig_lookup[track_paramset:get("track_retrig_time_"..target.."_"..hill_number..'_'..pages..'_'..i)]
+      track[target][hill_number][pages].conditional.retrig_slope[i] = 0
+
+      track[target][hill_number][pages].fill.base_note[i] = -1
+      track[target][hill_number][pages].fill.chord_notes[i] = {0,0,0}
+      track[target][hill_number][pages].fill.seed_default_note[i] = true
+      track[target][hill_number][pages].fill.chord_degrees[i] = 1
+      track[target][hill_number][pages].fill.velocities[i] = 127
+      track[target][hill_number][pages].fill.trigs[i] = false
+      track[target][hill_number][pages].fill.muted_trigs[i] = false
+      track[target][hill_number][pages].fill.accented_trigs[i] = false
+      track[target][hill_number][pages].fill.legato_trigs[i] = false
+      track[target][hill_number][pages].fill.lock_trigs[i] = false
+      track[target][hill_number][pages].fill.prob[i] = 100
+      track[target][hill_number][pages].fill.conditional.A[i] = 1
+      track[target][hill_number][pages].fill.conditional.B[i] = 1
+      track[target][hill_number][pages].fill.conditional.mode[i] = "A:B"
+      track[target][hill_number][pages].fill.conditional.retrig_count[i] = 0
+      track[target][hill_number][pages].fill.conditional.retrig_time[i] = track_retrig_lookup[track_paramset:get("track_fill_retrig_time_"..target.."_"..hill_number..'_'..pages..'_'..i)]
+      track[target][hill_number][pages].fill.conditional.retrig_slope[i] = 0
     end
-    track[target][hill_number].conditional.retrig_time[i] = track_retrig_lookup[track_paramset:get("track_retrig_time_"..target.."_"..hill_number..'_'..i)]
-    track[target][hill_number].conditional.retrig_slope[i] = 0
-    
-    track[target][hill_number].fill.base_note[i] = -1
-    track[target][hill_number].fill.chord_notes[i] = {0,0,0}
-    track[target][hill_number].fill.seed_default_note[i] = true
-    track[target][hill_number].fill.chord_degrees[i] = 1
-    track[target][hill_number].fill.velocities[i] = 127
-    track[target][hill_number].fill.trigs[i] = false
-    track[target][hill_number].fill.muted_trigs[i] = false
-    track[target][hill_number].fill.accented_trigs[i] = false
-    track[target][hill_number].fill.legato_trigs[i] = false
-    track[target][hill_number].fill.lock_trigs[i] = false
-    track[target][hill_number].fill.prob[i] = 100
-    track[target][hill_number].fill.conditional.A[i] = 1
-    track[target][hill_number].fill.conditional.B[i] = 1
-    track[target][hill_number].fill.conditional.mode[i] = "A:B"
-    track[target][hill_number].fill.conditional.retrig_count[i] = 0
-    track[target][hill_number].fill.conditional.retrig_time[i] = track_retrig_lookup[track_paramset:get("track_fill_retrig_time_"..target.."_"..hill_number..'_'..i)]
-    track[target][hill_number].fill.conditional.retrig_slope[i] = 0
   end
 
-  track[target][hill_number].gate = {}
-  track[target][hill_number].gate.active = false
-  track[target][hill_number].gate.prob = 0
   track[target][hill_number].swing = 50
   track[target][hill_number].mode = "fwd"
-  track[target][hill_number].start_point = 1
-  track[target][hill_number].end_point = 16
-  track[target][hill_number].down = 0
   track[target][hill_number].loop = true
   if build_clock then
     track_clock[target] = clock.run(track_actions.iterate,target)
@@ -298,14 +305,6 @@ function track_actions.init(target, hill_number, clear_reset)
 
   print('initializing track: '..target..', '..util.time())
 end
-
--- function track_actions.add(target, value)
---   local _active = track[target][track[target].active_hill]
---   if _active.hold then
---     table.insert(_active.notes, value)
---     _active.end_point = #_active.notes
---   end
--- end
 
 function track_actions.change_pattern(i,j,source)
   track_actions.stop_playback(i)
@@ -315,27 +314,21 @@ function track_actions.change_pattern(i,j,source)
   track_actions.start_playback(i,j)
 end
 
-function track_actions.enable(target,state)
-  track[target][track[target].active_hill].enabled = state
-end
-
--- function track_actions.toggle(state,target)
---   local i = target
---   if state == "start" then
---     track_actions.start_playback(i)
---   elseif state == "stop" then
---     track_actions.stop_playback(i)
---   end
--- end
-
 function track_actions.start_playback(i,j)
-  track[i][j].micro[0] = track[i][j].micro[1]
+  local _page;
+  for p = 1,8 do
+    if track[i][j].page_active[p] then
+      _page = p
+      break
+    end
+  end
+  track[i][j][_page].micro[0] = track[i][j][_page].micro[1]
   local track_start =
   {
-    ["fwd"] = track[i][j].start_point - 1
-  , ["bkwd"] = track[i][j].end_point + 1
-  , ["pend"] = track[i][j].start_point
-  , ["rnd"] = track[i][j].start_point - 1
+    ["fwd"] = track[i][j][_page].start_point - 1
+  , ["bkwd"] = track[i][j][_page].end_point + 1
+  , ["pend"] = track[i][j][_page].start_point
+  , ["rnd"] = track[i][j][_page].start_point - 1
   }
   track[i][j].step = track_start[track[i][j].mode]
   track[i][j].pause = false
@@ -343,50 +336,44 @@ function track_actions.start_playback(i,j)
   if track[i][j].mode == "pend" then
     track_direction[i] = "negative"
   end
-  -- TODO: fix up later! this needs to be wrapped in transport logic
-  -- local external_transport = false
-  -- for i = 1,16 do
-  --   if params:string("port_"..i.."_start_stop_in") == "yes" then
-  --     external_transport = true
-  --     break
-  --   end
-  -- end
-  -- if not transport.is_running and not external_transport then
-  --   print("should start transport...2")
-  --   transport.toggle_transport()
-  -- end
-  -- if params:string("track_"..i.."_hold_style") == "sequencer" then
-  --   if track[i].enabled then track_actions.enable(i,false) end
-  -- end
-  -- grid_dirty = true
 end
 
 function track_actions.stop_playback(i)
   local j = track[i].active_hill
+  local _page = track[i][j].page
   track[i][j].pause = true
   track[i][j].playing = false
   -- track[i][j].step = track[i][j].start_point
-  track[i][j].conditional.cycle = 1
+  track[i][j][_page].conditional.cycle = 1
+  for p = 1,8 do
+    if track[i][j].page_active[p] then
+      _page = p
+      break
+    end
+  end
   local track_start =
   {
-    ["fwd"] = track[i][j].start_point - 1
-  , ["bkwd"] = track[i][j].end_point + 1
-  , ["pend"] = track[i][j].start_point
-  , ["rnd"] = track[i][j].start_point - 1
+    ["fwd"] = track[i][j][_page].start_point - 1
+  , ["bkwd"] = track[i][j][_page].end_point + 1
+  , ["pend"] = track[i][j][_page].start_point
+  , ["rnd"] = track[i][j][_page].start_point - 1
   }
   track[i][j].step = track_start[track[i][j].mode]
-  -- grid_dirty = true
 end
 
 function track_actions.sync_playheads()
   for i = 1,number_of_hills do
-    track[i][track[i].active_hill].step = track[i][track[i].active_hill].start_point
+    track[i][track[i].active_hill].step = track[i][track[i].active_hill][1].start_point
   end
 end
 
 function track_actions.iterate(target)
   while true do
-    clock.sync(track[target][track[target].active_hill].time, track[target][track[target].active_hill].micro[track[target][track[target].active_hill].step]/384)
+    local i,j = target, track[target].active_hill
+    clock.sync(
+      track[i][j].time,
+      track[i][j][track[i][j].page].micro[track[i][j].step]/384
+    )
     track_actions.tick(target)
   end
 end
@@ -394,11 +381,12 @@ end
 function track_actions.tick(target) -- FIXME: shouldn't just trigger all voices all the time...
   if song_atoms.transport_active or params:string('hill_'..target..'_iterator') ~= 'norns' then
     local _active = track[target][track[target].active_hill]
+    local _a = track[target][track[target].active_hill][track[target][track[target].active_hill].page]
     local focused_set = _active.focus == "main" and _active or _active.fill
     -- if tab.count(_active.notes) > 0 then
     if _active.pause == false or params:string('hill_'..target..'_iterator') ~= 'norns' then
       -- print(_active.step, clock.get_beats(),track[1].notes[1])
-      if _active.step == _active.end_point and not _active.loop then
+      if _active.step == _a.end_point and not _active.loop then
         track_actions.stop_playback(target)
       else
         if _active.swing > 50 and _active.step % 2 == 1 then
@@ -423,43 +411,43 @@ function track_actions.tick(target) -- FIXME: shouldn't just trigger all voices 
   end
 end
 
-function track_actions.prob_fill(target,s_p,e_p,value)
-  local _active = track[target][track[target].active_hill]
-  local focused_set = _active.focus == "main" and _active or _active.fill
-  for i = s_p,e_p do
-    focused_set.prob[i] = value
-  end
-end
+-- function track_actions.prob_fill(target,s_p,e_p,value)
+--   local _active = track[target][track[target].active_hill]
+--   local focused_set = _active.focus == "main" and _active or _active.fill
+--   for i = s_p,e_p do
+--     focused_set.prob[i] = value
+--   end
+-- end
 
-function track_actions.cond_fill(target,s_p,e_p,a_val,b_val) -- TODO: gets weird...
-  local _active = track[target][track[target].active_hill]
-  local focused_set = _active.focus == "main" and _active or _active.fill
-  if b_val ~= "meta" then
-    for i = s_p,e_p do
-      focused_set.conditional.A[i] = a_val
-      focused_set.conditional.B[i] = b_val
-      focused_set.conditional.mode[i] = "A:B"
-    end
-  else
-    for i = s_p,e_p do
-      focused_set.conditional.mode[i] = a_val
-    end
-  end
-end
+-- function track_actions.cond_fill(target,s_p,e_p,a_val,b_val) -- TODO: gets weird...
+--   local _active = track[target][track[target].active_hill]
+--   local focused_set = _active.focus == "main" and _active or _active.fill
+--   if b_val ~= "meta" then
+--     for i = s_p,e_p do
+--       focused_set.conditional.A[i] = a_val
+--       focused_set.conditional.B[i] = b_val
+--       focused_set.conditional.mode[i] = "A:B"
+--     end
+--   else
+--     for i = s_p,e_p do
+--       focused_set.conditional.mode[i] = a_val
+--     end
+--   end
+-- end
 
-function track_actions.retrig_fill(target,s_p,e_p,val,type)
-  local _active = track[target][track[target].active_hill]
-  local focused_set = _active.focus == "main" and _active or _active.fill
-  if type == "retrig_count" then
-    for i = s_p,e_p do
-      focused_set.conditional[type][i] = val
-    end
-  else
-    for i = s_p,e_p do
-      track_paramset:set((_active.focus == "main" and "track_retrig_time_" or "track_fill_retrig_time_")..target.."_"..track[target].active_hill..'_'..i,val)
-    end
-  end
-end
+-- function track_actions.retrig_fill(target,s_p,e_p,val,type)
+--   local _active = track[target][track[target].active_hill]
+--   local focused_set = _active.focus == "main" and _active or _active.fill
+--   if type == "retrig_count" then
+--     for i = s_p,e_p do
+--       focused_set.conditional[type][i] = val
+--     end
+--   else
+--     for i = s_p,e_p do
+--       track_paramset:set((_active.focus == "main" and "track_retrig_time_" or "track_fill_retrig_time_")..target.."_"..track[target].active_hill..'_'..i,val)
+--     end
+--   end
+-- end
 
 function track_actions.change_trig_state(target_track,target_step,state, i, j)
   target_track.trigs[target_step] = state
@@ -476,10 +464,8 @@ function track_actions.copy(target,pattern)
     track_clipboard = _t.deep_copy(_active)
 
     track_clipboard.playing = false
-    track_clipboard.down = 0
     track_clipboard.pause = false
     track_clipboard.step = 1
-    track_clipboard.enabled = false
 
     track_clipboard_bank_source = target
     track_clipboard_pattern_source = pattern
@@ -739,17 +725,6 @@ function track_actions.run(target,step)
   end
 end
 
-function track_actions.check_gate_prob(target)
-  local _active = track[target][track[target].active_hill]
-  if  _active.gate.prob == 0 then
-    return false
-  elseif _active.gate.prob >= math.random(1,100) then
-    return true
-  else
-    return false
-  end
-end
-
 -- function track_actions.execute_step(target,step)
 --   track_actions.resolve_step(target, step)
 -- end
@@ -887,12 +862,6 @@ function track_actions.loadstate()
     end
   end
   track_paramset:read(_path.data.."cheat_codes_yellow/track/collection-"..collection.."/paramset.data")
-end
-
-function track_actions.restore_collection()
-  for i = 1,3 do
-    track[i].down = track[i].down == nil and 0 or track[i].down
-  end
 end
 
 return track_actions

--- a/lib/key_actions.lua
+++ b/lib/key_actions.lua
@@ -82,7 +82,7 @@ function key_actions.parse(n,z)
                 end
               elseif ui.menu_focus == 2 then
                 if key1_hold and _s.popup_focus.tracks[i][2] == 4 then
-                  _htracks.generate_er(i,j)
+                  _htracks.generate_er(i,j,highway_ui.seq_page[i])
                 end
               elseif ui.menu_focus == 3 then
                 _htracks.reset_note_to_default(i,j)

--- a/lib/parameters.lua
+++ b/lib/parameters.lua
@@ -59,7 +59,8 @@ function parameters.init()
       if x == 1 then
         if hills[i].highway then
           if not clock.threads[track_clock[i]] then
-            track[i][track[i].active_hill].micro[0] = track[i][track[i].active_hill].micro[1]
+            local _page = track[i][track[i].active_hill].page
+            track[i][track[i].active_hill][_page].micro[0] = track[i][track[i].active_hill][_page].micro[1]
             _htracks.start_playback(i,track[i].active_hill)
             track_clock[i] = clock.run(_htracks.iterate,i)
           end

--- a/lib/song.lua
+++ b/lib/song.lua
@@ -87,6 +87,7 @@ song.check_step = function(i)
 end
 
 song.start = function()
+  print('song starting! TODO: fix double trigger')
   if song_atoms.clock ~= nil then
     clock.cancel(song_atoms.clock)
   end
@@ -173,6 +174,7 @@ function song.toggle_transport()
         clock.cancel(track_clock[i])
       end
       if params:string('hill_'..i..'_iterator') == 'norns' then
+        if i == 1 then print('starting') end
         _htracks.start_playback(i, track[i].active_hill)
         track_clock[i] = clock.run(_htracks.iterate,i)
       end

--- a/lib/transformations.lua
+++ b/lib/transformations.lua
@@ -24,35 +24,32 @@ m.transpose = function(i,j,pos,delta)
   hills[i][j].note_num.chord_degree[pos] = util.wrap(hills[i][j].note_num.pool[pos], 1, 7)
 end
 
-m.track_transpose = function(i,j,pos,delta)
+m.track_transpose = function(i,j,_page,pos,delta)
   local _active = track[i][j]
+  local _a = _active[_active.page]
   local focused_set = {}
   if _active.focus == "main" then
     focused_set = _active.base_note
-    if _active.trigs[pos] == false then
+    if _a.trigs[pos] == false then
       if delta > 0 then
-        -- _active.trigs[pos] = true
-        _htracks.change_trig_state(_active,pos, true, i, j)
+        _htracks.change_trig_state(_a,pos, true, i, j, _page)
       end
       goto finished
     end
   else
-    focused_set = _active.fill.base_note
-    if _active.fill.trigs[pos] == false then
+    focused_set = _a.fill.base_note
+    if _a.fill.trigs[pos] == false then
       if delta > 0 then
-        -- _active.fill.trigs[pos] = true
-        _htracks.change_trig_state(_active.fill,pos, true, i, j)
+        _htracks.change_trig_state(_a.fill,pos, true, i, j, _page)
       end
       goto finished
     end
   end
   if focused_set[pos] == 0 and delta < 1 then
     if focused_set == _active.base_note then
-      -- _active.trigs[pos] = false
-      _htracks.change_trig_state(_active,pos, false, i, j)
+      _htracks.change_trig_state(_a,pos, false, i, j, _page)
     else
-      -- _active.fill.trigs[pos] = false
-      _htracks.change_trig_state(_active.fill,pos, true, i, j)
+      _htracks.change_trig_state(_a.fill,pos, true, i, j, _page)
     end
     local note_check;
     if params:string('voice_model_'..i) ~= 'sample' and params:string('voice_model_'..i) ~= 'input' then
@@ -140,11 +137,12 @@ m['rotate notes'] = function(i,j,start_point,end_point,focus,sc)
 end
 
 m['rotate track notes'] = function(i,j)
-  local target = track[i][j].focus == 'main' and track[i][j].base_note or track[i][j].fill.base_note
+  local _page = track[i][j].page
+  local target = track[i][j].focus == 'main' and track[i][j][_page].base_note or track[i][j][_page].fill.base_note
   local originals = {}
   local steps_with_trigs
-  for k = track[i][j].start_point, track[i][j].end_point do
-    if track[i][j].trigs[k] then
+  for k = track[i][j][_page].start_point, track[i][j][_page].end_point do
+    if track[i][j][_page].trigs[k] then
       originals[k] = target[k]
     else
       originals[k] = 'none'
@@ -153,8 +151,8 @@ m['rotate track notes'] = function(i,j)
   tab.print(originals)
   for k = 1,#originals do
     if originals[k] ~= 'none' then
-      print('rotate track notes: '..util.wrap(track[i][j].start_point+k, track[i][j].start_point, track[i][j].end_point), originals[k])
-      target[util.wrap(track[i][j].start_point+k, track[i][j].start_point, track[i][j].end_point)] = originals[k]
+      print('rotate track notes: '..util.wrap(track[i][j][_page].start_point+k, track[i][j][_page].start_point, track[i][j][_page].end_point), originals[k])
+      target[util.wrap(track[i][j][_page].start_point+k, track[i][j][_page].start_point, track[i][j][_page].end_point)] = originals[k]
     end
   end
 end


### PR DESCRIPTION
previously, all patterns just had 128 steps and 'pages' were a UI mechanism which allowed you to focus on a particular 16-step subset.

this always felt a little funky, but i was operating from an assumption that there were no models for how things could/would look otherwise -- until Fors.fm released Opal 1.2 which has 128 steps broken up in 8 functional 16-step pages, where each one is a standalone data container. it's friggin' rad and a wonderful way to achieve things like 3/4 meter without needing to figure out the interrelated maths of distributing within 36 steps across 2 16 step pages and 4 additional steps on the third.

this series of commits breaks the `track[i][j][step]` structure into `track[i][j][page][step]`, which required undoing a lot of shoddy scaling across the whole script -- for the future, that should be the first clue that the data needs cleaned up 😅